### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -1,5 +1,8 @@
 name: Branch Name Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]


### PR DESCRIPTION
Potential fix for [https://github.com/superfill-ai/superfill.ai/security/code-scanning/5](https://github.com/superfill-ai/superfill.ai/security/code-scanning/5)

In general, the fix is to explicitly declare a `permissions` block in the workflow (either at the top level or under the specific job) so that the `GITHUB_TOKEN` has only the minimal required access. Since this workflow just checks the branch name using the `github.head_ref` context and does not perform any write operations, we can safely set `permissions: contents: read` at the workflow root, which will apply to all jobs that do not override it.

The best fix without changing functionality is to add a top-level `permissions` block right below the `name: Branch Name Check` line in `.github/workflows/branch-name-check.yml`. This keeps behavior identical while constraining the token. No imports, methods, or additional definitions are needed; it's purely a YAML configuration change. If later the workflow needs more granular permissions (e.g., to comment on PRs), they can be added explicitly under this block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
